### PR TITLE
Add storage-based WiFi credentials update mechanism

### DIFF
--- a/kvmapp/system/init.d/S30wifi
+++ b/kvmapp/system/init.d/S30wifi
@@ -50,6 +50,17 @@ start() {
     echo "wifi mode: sta"
     ssid=""
     pass=""
+    if [ -e /boot/wifi.ssid ] && [ -e /boot/wifi.pass ]; then
+        echo "Updating WiFi credentials from /boot to /etc/kvm/"
+
+        rm -f /etc/kvm/wifi.ssid /etc/kvm/wifi.pass
+
+        mv /boot/wifi.ssid /etc/kvm/wifi.ssid
+        mv /boot/wifi.pass /etc/kvm/wifi.pass
+
+        chown root:root /etc/kvm/wifi.ssid /etc/kvm/wifi.pass
+        chmod 644 /etc/kvm/wifi.ssid /etc/kvm/wifi.pass
+    fi
     if [ -e /etc/kvm/wifi.ssid ]
     then
         ssid=`cat /etc/kvm/wifi.ssid`


### PR DESCRIPTION
Hi,

This PR enhances WiFi credential management by introducing a fallback mechanism for updating WiFi credentials when network connectivity is unreliable. Key changes include:

- When /boot/wifi.ssid and /boot/wifi.pass exist, they are moved to /etc/kvm/
- Old credential files are removed before updating
- Ownership and permissions are properly set (root:root, 644)
- Ensures smoother WiFi setup in case of connection issues

Thanks